### PR TITLE
Convert user_agents_total_transactions_count to float

### DIFF
--- a/trafficserver_exporter/collector.py
+++ b/trafficserver_exporter/collector.py
@@ -189,7 +189,7 @@ class StatsPluginCollector(object):
         )
         metric.add_sample(
             "trafficserver_transactions_total",
-            value=data[("proxy.node.http." "user_agents_total_transactions_count")],
+            value=float(data[("proxy.node.http." "user_agents_total_transactions_count")]),
             labels={"source": "user_agent", "protocol": "http"},
         )
         metric.add_sample(


### PR DESCRIPTION
Without converting the value to float, the exporter crashes with a
TypeError exception. It seems that user_agents_total_transactions_count
was forgotten in 66d243c.