### PR TITLE
Swap bytes total/used in cache available/used metrics

### DIFF
--- a/trafficserver_exporter/collector.py
+++ b/trafficserver_exporter/collector.py
@@ -688,7 +688,7 @@ class StatsPluginCollector(object):
         metric.add_sample(
             "trafficserver_cache_avail_size_bytes_total",
             value=float(
-                data["proxy.process.cache.volume_{0}.bytes_used".format(volume)]
+                data["proxy.process.cache.volume_{0}.bytes_total".format(volume)]
             ),
             labels={"volume": str(volume)},
         )
@@ -702,7 +702,7 @@ class StatsPluginCollector(object):
         metric.add_sample(
             "trafficserver_cache_used_bytes_total",
             value=float(
-                data["proxy.process.cache.volume_{0}.bytes_total".format(volume)]
+                data["proxy.process.cache.volume_{0}.bytes_used".format(volume)]
             ),
             labels={"volume": str(volume)},
         )


### PR DESCRIPTION
The right value for trafficserver_cache_avail_size_bytes_total is
bytes_total, while for trafficserver_cache_used_bytes_total it is
bytes_used.