### PR TITLE
Allow skipping SSL verification

### DIFF
--- a/trafficserver_exporter/collector.py
+++ b/trafficserver_exporter/collector.py
@@ -79,9 +79,10 @@ def _get_float_value(data, keys):
 class StatsPluginCollector(object):
     """Collector for metrics from the stats_over_http plugin."""
 
-    def __init__(self, endpoint, max_retries=0):
+    def __init__(self, endpoint, max_retries=0, ssl_verify=True):
         """Instantiate a new Collector for ATS stats."""
         self._endpoint = endpoint
+        self._ssl_verify = ssl_verify
         self.log = LOG
         self.session = requests.Session()
         http_adapter = requests.adapters.HTTPAdapter(max_retries=max_retries)
@@ -90,9 +91,8 @@ class StatsPluginCollector(object):
 
     def get_json(self):
         """Query the ATS stats endpoint, return parsed JSON."""
-        return json.loads(requests.get(self._endpoint).content.decode("UTF-8"))[
-            "global"
-        ]
+        r = requests.get(self._endpoint, verify=self._ssl_verify)
+        return r.json()["global"]
 
     def collect(self):
         """Generator used to gather and return all metrics."""

--- a/trafficserver_exporter/trafficserver_exporter.py
+++ b/trafficserver_exporter/trafficserver_exporter.py
@@ -45,6 +45,13 @@ ARGS.add_argument(
 )
 ARGS.set_defaults(procstats=True)
 ARGS.add_argument(
+    "--no-ssl-verification",
+    dest="sslverification",
+    action="store_false",
+    help="Disable SSL certificate verification on metric collection",
+)
+ARGS.set_defaults(sslverification=True)
+ARGS.add_argument(
     "--max-retries",
     dest="max_retries",
     type=int,
@@ -92,7 +99,8 @@ def main():
     httpd_thread = start_http_server(args.port, addr=args.addr)
 
     LOG.debug("Registering StatsPluginCollector")
-    REGISTRY.register(StatsPluginCollector(args.endpoint, max_retries=args.max_retries))
+    REGISTRY.register(StatsPluginCollector(args.endpoint, max_retries=args.max_retries,
+                                           ssl_verify=args.sslverification))
 
     if args.procstats:
         LOG.debug("Registering ProcessCollector")


### PR DESCRIPTION
In some scenarios where trafficserver is configured to serve TLS traffic is not easy to provide a certificate that matches https://localhost.
Skipping SSL verification allows fetching the _stats endpoint in those environments.