### PR TITLE
Introduce a metrics yaml config file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,12 @@ setup(
             'trafficserver_exporter=trafficserver_exporter.__main__:main'
         ],
     },
+    package_data={
+        'trafficserver_exporter': ['metrics.yaml'],
+    },
     install_requires=[
         'prometheus_client>=0.0.11',
+        'pyyaml>=3.12',
         'requests>=2.0.0'
     ],
     classifiers=[

--- a/tests/test_stats_plugin_collector.py
+++ b/tests/test_stats_plugin_collector.py
@@ -1,9 +1,13 @@
+import sys
+from os import path
+
 import prometheus_client
 
 from trafficserver_exporter.collector import StatsPluginCollector
 
 
 def test_metric_parser(stats_json):
-    collector = StatsPluginCollector("")
+    metrics_file_path = path.join(path.dirname(sys.modules['trafficserver_exporter'].__file__), 'metrics.yaml')
+    collector = StatsPluginCollector("", metrics_file_path)
     for metric in collector.parse_metrics(stats_json["global"]):
         assert isinstance(metric, prometheus_client.core.Metric)

--- a/trafficserver_exporter/collector.py
+++ b/trafficserver_exporter/collector.py
@@ -1,60 +1,13 @@
 """Prometheus collector for Apache Traffic Server's stats_over_http plugin."""
 
 import logging
-import json
 import re
 import time
 
 import requests
+import yaml
 from prometheus_client import Metric
 
-
-HTTP_VERBS = ("GET", "HEAD", "POST", "PUT", "PUSH", "DELETE", "PURGE")
-HTTP_VERBS_LOWER = tuple([v.lower() for v in HTTP_VERBS])
-
-TS_RESPONSE_CODES = (
-    "100",
-    "101",
-    "200",
-    "201",
-    "202",
-    "203",
-    "204",
-    "205",
-    "206",
-    "300",
-    "301",
-    "302",
-    "303",
-    "304",
-    "305",
-    "307",
-    "400",
-    "401",
-    "402",
-    "403",
-    "404",
-    "405",
-    "406",
-    "407",
-    "408",
-    "409",
-    "410",
-    "411",
-    "412",
-    "413",
-    "414",
-    "415",
-    "416",
-    "500",
-    "501",
-    "502",
-    "503",
-    "504",
-    "505",
-)
-
-TS_RESPONSE_CODE_CLASSES = ("1xx", "2xx", "3xx", "4xx", "5xx")
 
 CACHE_VOLUMES = re.compile("^proxy.process.cache.volume_([0-9]+)")
 
@@ -79,7 +32,7 @@ def _get_float_value(data, keys):
 class StatsPluginCollector(object):
     """Collector for metrics from the stats_over_http plugin."""
 
-    def __init__(self, endpoint, max_retries=0, ssl_verify=True):
+    def __init__(self, endpoint, metrics_config_file, max_retries=0, ssl_verify=True):
         """Instantiate a new Collector for ATS stats."""
         self._endpoint = endpoint
         self._ssl_verify = ssl_verify
@@ -88,6 +41,8 @@ class StatsPluginCollector(object):
         http_adapter = requests.adapters.HTTPAdapter(max_retries=max_retries)
         for prefix in ("http://", "https://"):
             self.session.mount(prefix, http_adapter)
+        with open(metrics_config_file, 'rb') as metrics_file:
+            self._metrics = yaml.safe_load(metrics_file.read())
 
     def get_json(self):
         """Query the ATS stats endpoint, return parsed JSON."""
@@ -124,442 +79,25 @@ class StatsPluginCollector(object):
 
     def parse_metrics(self, data):
         """Generator for trafficserver metrics."""
-        # Counter for server restarts
-        metric = Metric(
-            "trafficserver_restart_count",
-            "Count of traffic_server restarts.",
-            "counter",
-        )
-        metric.add_sample(
-            "trafficserver_restart_count",
-            value=float(data["proxy.node.restarts.proxy.restart_count"]),
-            labels={},
-        )
-        yield metric
 
-        #
-        # HTTP
-        #
-        # Connections
-        metric = Metric(
-            "trafficserver_connections_total", "Connection count.", "counter"
-        )
-        metric.add_sample(
-            "trafficserver_connections_total",
-            value=float(data["proxy.process.http.total_client_connections"]),
-            labels={"source": "client", "protocol": "http"},
-        )
-        metric.add_sample(
-            "trafficserver_connections_total",
-            value=float(data["proxy.process.http.total_server_connections"]),
-            labels={"source": "server", "protocol": "http"},
-        )
-        metric.add_sample(
-            "trafficserver_connections_total",
-            value=float(data["proxy.process.http.total_parent_proxy_connections"]),
-            labels={"source": "parent_proxy", "protocol": "http"},
-        )
-        yield metric
+        for metric_name, metric_cfg in self._metrics.items():
+            metric = Metric(metric_name, metric_cfg['documentation'], metric_cfg['type'])
+            for metric_value in metric_cfg['values']:
+                if isinstance(metric_value['value'], float):
+                    value = metric_value['value']
+                else:
+                    try:
+                        value = float(data[metric_value['value']])
+                    except ValueError:
+                        self.log.warning("Unable to convert metric %s value %s to float",
+                                         metric_name, metric_value['value'])
+                    except KeyError:
+                        self.log.debug("Metric %s value %s not found",
+                                       metric_name, metric_value['value'])
+                        continue
 
-        # Incoming requests
-        metric = Metric(
-            "trafficserver_requests_incoming", "Incoming requests.", "gauge"
-        )
-        metric.add_sample(
-            "trafficserver_requests_incoming",
-            value=float(data["proxy.process.http.incoming_requests"]),
-            labels={"protocol": "http"},
-        )
-        yield metric
-
-        # Incoming responses
-        metric = Metric(
-            "trafficserver_responses_incoming_total", "Incoming responses.", "counter"
-        )
-        metric.add_sample(
-            "trafficserver_responses_incoming_total",
-            value=float(data["proxy.process.http.incoming_responses"]),
-            labels={"protocol": "http"},
-        )
-        yield metric
-
-        # Outgoing requests
-        metric = Metric(
-            "trafficserver_requests_outgoing_total", "Outgoing requests.", "counter"
-        )
-        metric.add_sample(
-            "trafficserver_requests_outgoing_total",
-            value=float(data["proxy.process.http.outgoing_requests"]),
-            labels={"protocol": "http"},
-        )
-        yield metric
-
-        # Client aborts
-        metric = Metric(
-            "trafficserver_error_client_aborts_total", "Client aborts.", "counter"
-        )
-        metric.add_sample(
-            "trafficserver_client_aborts_total",
-            value=float(data["proxy.process.http.err_client_abort_count_stat"]),
-            labels={"protocol": "http"},
-        )
-        yield metric
-
-        # Connect fails
-        metric = Metric(
-            "trafficserver_connect_failures_total", "Connect failures.", "counter"
-        )
-        metric.add_sample(
-            "trafficserver_connect_failures_total",
-            value=float(data["proxy.process.http.err_connect_fail_count_stat"]),
-            labels={"protocol": "http"},
-        )
-        yield metric
-
-        # Transaction count
-        metric = Metric(
-            "trafficserver_transactions_total", "Total transactions.", "counter"
-        )
-        try:
-            metric.add_sample(
-                "trafficserver_transactions_total",
-                value=float(
-                    data["proxy.node.http.user_agents_total_transactions_count"]
-                ),
-                labels={"source": "user_agent", "protocol": "http"},
-            )
-            metric.add_sample(
-                "trafficserver_transactions_total",
-                value=float(
-                    data["proxy.node.http.origin_server_total_transactions_count"]
-                ),
-                labels={"source": "origin_server", "protocol": "http"},
-            )
+                metric.add_sample(metric_name, value=value, labels=metric_value['labels'])
             yield metric
-        except KeyError:
-            # TS v8.0+ removed these metrics.
-            pass
-
-        # Transaction time spent, total
-        metric = Metric(
-            "trafficserver_transactions_time_ms_total",
-            "Total transaction time (ms).",
-            "counter",
-        )
-        metric.add_sample(
-            "trafficserver_transactions_time_total",
-            value=float(data["proxy.process.http.total_transactions_time"]),
-            labels={},
-        )
-        yield metric
-
-        # Transaction time spent, hits
-        metric = Metric(
-            "trafficserver_hit_transaction_time_ms_total",
-            "Total cache hit transaction time (ms).",
-            "counter",
-        )
-        metric.add_sample(
-            "trafficserver_hit_transaction_time_ms_total",
-            value=float(data["proxy.process.http.transaction_totaltime.hit_fresh"]),
-            labels={"state": "fresh", "protocol": "http"},
-        )
-        metric.add_sample(
-            "trafficserver_hit_transaction_time_ms_total",
-            value=float(
-                data["proxy.process.http.transaction_totaltime.hit_revalidated"]
-            ),
-            labels={"state": "revalidated", "protocol": "http"},
-        )
-        yield metric
-
-        # Transaction time spent, misses
-        metric = Metric(
-            "trafficserver_miss_transaction_time_ms_total",
-            "Total cache miss transaction time (ms).",
-            "counter",
-        )
-        metric.add_sample(
-            "trafficserver_miss_transaction_time_ms_total",
-            value=float(data["proxy.process.http.transaction_totaltime.miss_cold"]),
-            labels={"state": "cold", "protocol": "http"},
-        )
-        metric.add_sample(
-            "trafficserver_miss_transaction_time_ms_total",
-            value=float(
-                data["proxy.process.http.transaction_totaltime.miss_not_cacheable"]
-            ),
-            labels={"state": "not_cacheable", "protocol": "http"},
-        )
-        metric.add_sample(
-            "trafficserver_miss_transaction_time_ms_total",
-            value=float(data["proxy.process.http.transaction_totaltime.miss_changed"]),
-            labels={"state": "changed", "protocol": "http"},
-        )
-        metric.add_sample(
-            "trafficserver_miss_transaction_time_ms_total",
-            value=float(
-                data["proxy.process.http.transaction_totaltime.miss_client_no_cache"]
-            ),
-            labels={"state": "no_cache", "protocol": "http"},
-        )
-        yield metric
-
-        # Transaction time spent, errors
-        metric = Metric(
-            "trafficserver_error_transaction_time_ms_total",
-            "Total cache error transaction time (ms).",
-            "counter",
-        )
-        metric.add_sample(
-            "trafficserver_error_transaction_time_ms_total",
-            value=float(data["proxy.process.http.transaction_totaltime.errors.aborts"]),
-            labels={"state": "abort", "protocol": "http"},
-        )
-        metric.add_sample(
-            "trafficserver_error_transaction_time_ms_total",
-            value=float(
-                data[
-                    (
-                        "proxy.process.http.transaction_totaltime."
-                        "errors.possible_aborts"
-                    )
-                ]
-            ),
-            labels={"state": "possible_abort", "protocol": "http"},
-        )
-        metric.add_sample(
-            "trafficserver_error_transaction_time_ms_total",
-            value=float(
-                data[
-                    (
-                        "proxy.process.http.transaction_totaltime."
-                        "errors.connect_failed"
-                    )
-                ]
-            ),
-            labels={"state": "connect_failed", "protocol": "http"},
-        )
-        metric.add_sample(
-            "trafficserver_error_transaction_time_ms_total",
-            value=float(
-                data[("proxy.process.http.transaction_totaltime." "errors.other")]
-            ),
-            labels={"state": "other", "protocol": "http"},
-        )
-        yield metric
-
-        # Transaction time spent, other
-        metric = Metric(
-            "trafficserver_other_transaction_time_ms_total",
-            "Total other/unclassified transaction time (ms).",
-            "counter",
-        )
-        try:
-            metric.add_sample(
-                "trafficserver_other_transaction_time_ms_total",
-                value=float(
-                    data[
-                        (
-                            "proxy.process.http.transaction_totaltime."
-                            "errors.unclassified"
-                        )
-                    ]
-                ),
-                labels={"state": "unclassified", "protocol": "http"},
-            )
-        except KeyError:
-            pass
-        else:
-            yield metric
-
-        # Transaction count, hits
-        metric = Metric(
-            "trafficserver_transaction_hits_total", "Transaction hit counts.", "counter"
-        )
-        metric.add_sample(
-            "trafficserver_transaction_hits_total",
-            value=float(data["proxy.process.http.transaction_counts.hit_fresh"]),
-            labels={"state": "fresh", "protocol": "http"},
-        )
-        metric.add_sample(
-            "trafficserver_transaction_hits_total",
-            value=float(data["proxy.process.http.transaction_counts.hit_revalidated"]),
-            labels={"state": "revalidated", "protocol": "http"},
-        )
-        # Zero labels (misses)
-        metric.add_sample(
-            "trafficserver_transaction_hits_total",
-            value=0.0,
-            labels={"state": "cold", "protocol": "http"},
-        )
-        metric.add_sample(
-            "trafficserver_transaction_hits_total",
-            value=0.0,
-            labels={"state": "not_cacheable", "protocol": "http"},
-        )
-        metric.add_sample(
-            "trafficserver_transaction_hits_total",
-            value=0.0,
-            labels={"state": "changed", "protocol": "http"},
-        )
-        yield metric
-
-        # Transaction count, misses
-        metric = Metric(
-            "trafficserver_transaction_misses_total",
-            "Transaction miss counts.",
-            "counter",
-        )
-        metric.add_sample(
-            "trafficserver_transaction_misses_total",
-            value=float(data["proxy.process.http.transaction_counts.miss_cold"]),
-            labels={"state": "cold", "protocol": "http"},
-        )
-        metric.add_sample(
-            "trafficserver_transaction_misses_total",
-            value=float(
-                data["proxy.process.http.transaction_counts.miss_not_cacheable"]
-            ),
-            labels={"state": "not_cacheable", "protocol": "http"},
-        )
-        metric.add_sample(
-            "trafficserver_transaction_misses_total",
-            value=float(data["proxy.process.http.transaction_counts.miss_changed"]),
-            labels={"state": "changed", "protocol": "http"},
-        )
-        # Zero labels (hits)
-        metric.add_sample(
-            "trafficserver_transaction_misses_total",
-            value=0.0,
-            labels={"state": "fresh", "protocol": "http"},
-        )
-        metric.add_sample(
-            "trafficserver_transaction_misses_total",
-            value=0.0,
-            labels={"state": "revalidated", "protocol": "http"},
-        )
-        yield metric
-
-        # Transaction count, errors
-        metric = Metric(
-            "trafficserver_transaction_errors_total",
-            "Transaction error counts.",
-            "counter",
-        )
-        metric.add_sample(
-            "trafficserver_transaction_errors_total",
-            value=float(
-                data[("proxy.process.http.transaction_counts.errors." "aborts")]
-            ),
-            labels={"state": "abort", "protocol": "http"},
-        )
-        metric.add_sample(
-            "trafficserver_transaction_errors_total",
-            value=float(
-                data[
-                    ("proxy.process.http.transaction_counts.errors." "possible_aborts")
-                ]
-            ),
-            labels={"state": "possible_abort", "protocol": "http"},
-        )
-        metric.add_sample(
-            "trafficserver_transaction_errors_total",
-            value=float(
-                data[("proxy.process.http.transaction_counts.errors." "connect_failed")]
-            ),
-            labels={"state": "connect_failed", "protocol": "http"},
-        )
-        metric.add_sample(
-            "trafficserver_transaction_errors_total",
-            value=float(
-                data[("proxy.process.http.transaction_counts.errors." "other")]
-            ),
-            labels={"state": "other", "protocol": "http"},
-        )
-        yield metric
-
-        # Transaction count, others
-        metric = Metric(
-            "trafficserver_transaction_others_total",
-            "Transaction other/unclassified counts.",
-            "counter",
-        )
-        metric.add_sample(
-            "trafficserver_transaction_others_total",
-            value=float(
-                data[("proxy.process.http.transaction_counts.other." "unclassified")]
-            ),
-            labels={"state": "unclassified", "protocol": "http"},
-        )
-        yield metric
-
-        # HTTP Responses
-        metric = Metric("trafficserver_responses_total", "Response count.", "counter")
-        for code in TS_RESPONSE_CODES:
-            key = "proxy.process.http.{code}_responses".format(code=code)
-            metric.add_sample(
-                "trafficserver_responses_total",
-                value=float(data[key]),
-                labels={"code": code, "protocol": "http"},
-            )
-        yield metric
-
-        # HTTP Responses, by class
-        # This seems a little redundant in that it could be accomplished with
-        # a simple recording rule, but the HTTP response codes tracked don't
-        # appear to be the full array of codes, so they may be swept into this
-        # bucket.
-        metric = Metric(
-            "trafficserver_response_classes_total",
-            "Response count by class, i.e. 2xx, 3xx.",
-            "counter",
-        )
-        for code in TS_RESPONSE_CODE_CLASSES:
-            key = "proxy.process.http.{code}_responses".format(code=code)
-            metric.add_sample(
-                "trafficserver_response_classes_total",
-                value=float(data[key]),
-                labels={"code": code, "protocol": "http"},
-            )
-        yield metric
-
-        # HTTP Requests
-        metric = Metric("trafficserver_requests_total", "Request count.", "counter")
-        for method in HTTP_VERBS_LOWER:
-            key = "proxy.process.http.{method}_requests".format(method=method)
-            metric.add_sample(
-                "trafficserver_requests_total",
-                value=float(data[key]),
-                labels={"method": method, "protocol": "http"},
-            )
-        yield metric
-
-        # Invalid requests
-        metric = Metric(
-            "trafficserver_client_requests_invalid_total",
-            "Invalid client requests.",
-            "counter",
-        )
-        metric.add_sample(
-            "trafficserver_client_requests_invalid_total",
-            value=float(data["proxy.process.http.invalid_client_requests"]),
-            labels={"protocol": "http"},
-        )
-        yield metric
-
-        # Requests without Host header
-        metric = Metric(
-            "trafficserver_client_requests_missing_host_hdr_total",
-            "Client requests missing host header.",
-            "counter",
-        )
-        metric.add_sample(
-            "trafficserver_client_requests_missing_host_hdr_total",
-            value=float(data["proxy.process.http.missing_host_hdr"]),
-            labels={"protocol": "http"},
-        )
-        yield metric
 
         for rt in ("request", "response"):
             metric_name = "trafficserver_{}_size_bytes_total".format(rt)
@@ -656,40 +194,6 @@ class StatsPluginCollector(object):
         for volume in volumes:
             for metric in self._parse_volume_metrics(data, volume):
                 yield metric
-
-        metric = Metric(
-            "trafficserver_ram_cache_misses_total", "RAM cache miss count.", "counter"
-        )
-        metric.add_sample(
-            "trafficserver_ram_cache_misses_total",
-            value=float(data["proxy.process.cache.ram_cache.misses"]),
-            labels={},
-        )
-        yield metric
-
-        metric = Metric(
-            "trafficserver_ram_cache_avail_size_bytes_total",
-            "RAM cache available in bytes.",
-            "gauge",
-        )
-        metric.add_sample(
-            "trafficserver_ram_cache_avail_size_bytes_total",
-            value=float(data["proxy.process.cache.ram_cache.total_bytes"]),
-            labels={},
-        )
-        yield metric
-
-        metric = Metric(
-            "trafficserver_ram_cache_used_bytes_total",
-            "RAM cache used in bytes.",
-            "gauge",
-        )
-        metric.add_sample(
-            "trafficserver_ram_cache_used_bytes_total",
-            value=float(data["proxy.process.cache.ram_cache.bytes_used"]),
-            labels={},
-        )
-        yield metric
 
     def _parse_volume_metrics(self, data, volume):
         metric = Metric(

--- a/trafficserver_exporter/metrics.yaml
+++ b/trafficserver_exporter/metrics.yaml
@@ -1,0 +1,295 @@
+trafficserver_client_requests_invalid_total:
+  documentation: Invalid client requests.
+  type: counter
+  values:
+  - labels: {protocol: http}
+    value: proxy.process.http.invalid_client_requests
+trafficserver_client_requests_missing_host_hdr_total:
+  documentation: Client requests missing host header.
+  type: counter
+  values:
+  - labels: {protocol: http}
+    value: proxy.process.http.missing_host_hdr
+trafficserver_connect_failures_total:
+  documentation: Connect failures.
+  type: counter
+  values:
+  - labels: {protocol: http}
+    value: proxy.process.http.err_connect_fail_count_stat
+trafficserver_connections_total:
+  documentation: Connection count.
+  type: counter
+  values:
+  - labels: {protocol: http, source: client}
+    value: proxy.process.http.total_client_connections
+  - labels: {protocol: http, source: server}
+    value: proxy.process.http.total_server_connections
+  - labels: {protocol: http, source: parent_proxy}
+    value: proxy.process.http.total_parent_proxy_connections
+trafficserver_error_client_aborts_total:
+  documentation: Client aborts.
+  type: counter
+  values:
+  - labels: {protocol: http}
+    value: proxy.process.http.err_client_abort_count_stat
+trafficserver_error_transaction_time_ms_total:
+  documentation: Total cache error transaction time (ms).
+  type: counter
+  values:
+  - labels: {protocol: http, state: abort}
+    value: proxy.process.http.transaction_totaltime.errors.aborts
+  - labels: {protocol: http, state: possible_abort}
+    value: proxy.process.http.transaction_totaltime.errors.possible_aborts
+  - labels: {protocol: http, state: connect_failed}
+    value: proxy.process.http.transaction_totaltime.errors.connect_failed
+  - labels: {protocol: http, state: other}
+    value: proxy.process.http.transaction_totaltime.errors.other
+trafficserver_hit_transaction_time_ms_total:
+  documentation: Total cache hit transaction time (ms).
+  type: counter
+  values:
+  - labels: {protocol: http, state: fresh}
+    value: proxy.process.http.transaction_totaltime.hit_fresh
+  - labels: {protocol: http, state: revalidated}
+    value: proxy.process.http.transaction_totaltime.hit_revalidated
+trafficserver_miss_transaction_time_ms_total:
+  documentation: Total cache miss transaction time (ms).
+  type: counter
+  values:
+  - labels: {protocol: http, state: cold}
+    value: proxy.process.http.transaction_totaltime.miss_cold
+  - labels: {protocol: http, state: not_cacheable}
+    value: proxy.process.http.transaction_totaltime.miss_not_cacheable
+  - labels: {protocol: http, state: changed}
+    value: proxy.process.http.transaction_totaltime.miss_changed
+  - labels: {protocol: http, state: no_cache}
+    value: proxy.process.http.transaction_totaltime.miss_client_no_cache
+trafficserver_other_transaction_time_ms_total:
+  documentation: Total other/unclassified transaction time (ms).
+  type: counter
+  values:
+  - labels: {protocol: http, state: connect_failed}
+    value: proxy.process.http.transaction_totaltime.errors.connect_failed
+  - labels: {protocol: http, state: other}
+    value: proxy.process.http.transaction_totaltime.errors.other
+  - labels: {protocol: http, state: possible_abort}
+    value: proxy.process.http.transaction_totaltime.errors.possible_aborts
+
+trafficserver_ram_cache_avail_size_bytes_total:
+  documentation: RAM cache available in bytes.
+  type: gauge
+  values:
+  - labels: {}
+    value: proxy.process.cache.ram_cache.total_bytes
+trafficserver_ram_cache_misses_total:
+  documentation: RAM cache miss count.
+  type: counter
+  values:
+  - labels: {}
+    value: proxy.process.cache.ram_cache.misses
+trafficserver_ram_cache_used_bytes_total:
+  documentation: RAM cache used in bytes.
+  type: gauge
+  values:
+  - labels: {}
+    value: proxy.process.cache.ram_cache.bytes_used
+trafficserver_requests_incoming:
+  documentation: Incoming requests.
+  type: gauge
+  values:
+  - labels: {protocol: http}
+    value: proxy.process.http.incoming_requests
+trafficserver_requests_outgoing_total:
+  documentation: Outgoing requests.
+  type: counter
+  values:
+  - labels: {protocol: http}
+    value: proxy.process.http.outgoing_requests
+trafficserver_requests_total:
+  documentation: Request count.
+  type: counter
+  values:
+  - labels: {method: connect, protocol: http}
+    value: proxy.process.http.connect_requests
+  - labels: {method: delete, protocol: http}
+    value: proxy.process.http.delete_requests
+  - labels: {method: get, protocol: http}
+    value: proxy.process.http.get_requests
+  - labels: {method: head, protocol: http}
+    value: proxy.process.http.head_requests
+  - labels: {method: post, protocol: http}
+    value: proxy.process.http.post_requests
+  - labels: {method: purge, protocol: http}
+    value: proxy.process.http.purge_requests
+  - labels: {method: push, protocol: http}
+    value: proxy.process.http.push_requests
+  - labels: {method: put, protocol: http}
+    value: proxy.process.http.put_requests
+trafficserver_response_classes_total:
+  documentation: Response count by class, i.e. 2xx, 3xx.
+  type: counter
+  values:
+  - labels: {code: 1xx, protocol: http}
+    value: proxy.process.http.1xx_responses
+  - labels: {code: 2xx, protocol: http}
+    value: proxy.process.http.1xx_responses
+  - labels: {code: 3xx, protocol: http}
+    value: proxy.process.http.1xx_responses
+  - labels: {code: 4xx, protocol: http}
+    value: proxy.process.http.1xx_responses
+  - labels: {code: 5xx, protocol: http}
+    value: proxy.process.http.1xx_responses
+trafficserver_responses_incoming_total:
+  documentation: Incoming responses.
+  type: counter
+  values:
+  - labels: {protocol: http}
+    value: proxy.process.http.incoming_responses
+trafficserver_responses_total:
+  documentation: Response count.
+  type: counter
+  values:
+  - labels: {code: "100", protocol: http}
+    value: proxy.process.http.100_responses
+  - labels: {code: "101", protocol: http}
+    value: proxy.process.http.101_responses
+  - labels: {code: "200", protocol: http}
+    value: proxy.process.http.200_responses
+  - labels: {code: "201", protocol: http}
+    value: proxy.process.http.201_responses
+  - labels: {code: "202", protocol: http}
+    value: proxy.process.http.202_responses
+  - labels: {code: "203", protocol: http}
+    value: proxy.process.http.203_responses
+  - labels: {code: "204", protocol: http}
+    value: proxy.process.http.204_responses
+  - labels: {code: "205", protocol: http}
+    value: proxy.process.http.205_responses
+  - labels: {code: "206", protocol: http}
+    value: proxy.process.http.206_responses
+  - labels: {code: "300", protocol: http}
+    value: proxy.process.http.300_responses
+  - labels: {code: "301", protocol: http}
+    value: proxy.process.http.301_responses
+  - labels: {code: "302", protocol: http}
+    value: proxy.process.http.302_responses
+  - labels: {code: "303", protocol: http}
+    value: proxy.process.http.303_responses
+  - labels: {code: "304", protocol: http}
+    value: proxy.process.http.304_responses
+  - labels: {code: "305", protocol: http}
+    value: proxy.process.http.305_responses
+  - labels: {code: "307", protocol: http}
+    value: proxy.process.http.307_responses
+  - labels: {code: "400", protocol: http}
+    value: proxy.process.http.400_responses
+  - labels: {code: "401", protocol: http}
+    value: proxy.process.http.401_responses
+  - labels: {code: "402", protocol: http}
+    value: proxy.process.http.402_responses
+  - labels: {code: "403", protocol: http}
+    value: proxy.process.http.403_responses
+  - labels: {code: "404", protocol: http}
+    value: proxy.process.http.404_responses
+  - labels: {code: "405", protocol: http}
+    value: proxy.process.http.405_responses
+  - labels: {code: "406", protocol: http}
+    value: proxy.process.http.406_responses
+  - labels: {code: "407", protocol: http}
+    value: proxy.process.http.407_responses
+  - labels: {code: "408", protocol: http}
+    value: proxy.process.http.408_responses
+  - labels: {code: "409", protocol: http}
+    value: proxy.process.http.409_responses
+  - labels: {code: "410", protocol: http}
+    value: proxy.process.http.410_responses
+  - labels: {code: "411", protocol: http}
+    value: proxy.process.http.411_responses
+  - labels: {code: "412", protocol: http}
+    value: proxy.process.http.412_responses
+  - labels: {code: "413", protocol: http}
+    value: proxy.process.http.413_responses
+  - labels: {code: "414", protocol: http}
+    value: proxy.process.http.414_responses
+  - labels: {code: "415", protocol: http}
+    value: proxy.process.http.415_responses
+  - labels: {code: "416", protocol: http}
+    value: proxy.process.http.416_responses
+  - labels: {code: "500", protocol: http}
+    value: proxy.process.http.500_responses
+  - labels: {code: "501", protocol: http}
+    value: proxy.process.http.501_responses
+  - labels: {code: "502", protocol: http}
+    value: proxy.process.http.502_responses
+  - labels: {code: "503", protocol: http}
+    value: proxy.process.http.503_responses
+  - labels: {code: "504", protocol: http}
+    value: proxy.process.http.504_responses
+  - labels: {code: "505", protocol: http}
+    value: proxy.process.http.505_responses
+trafficserver_restart_count:
+  documentation: Count of traffic_server restarts.
+  type: counter
+  values:
+  - labels: {}
+    value: proxy.node.restarts.proxy.restart_count
+trafficserver_transaction_errors_total:
+  documentation: Transaction error counts.
+  type: counter
+  values:
+  - labels: {protocol: http, state: abort}
+    value: proxy.process.http.transaction_counts.errors.aborts
+  - labels: {protocol: http, state: possible_abort}
+    value: proxy.process.http.transaction_counts.errors.possible_aborts
+  - labels: {protocol: http, state: connect_failed}
+    value: proxy.process.http.transaction_counts.errors.connect_failed
+  - labels: {protocol: http, state: other}
+    value: proxy.process.http.transaction_counts.errors.other
+trafficserver_transaction_hits_total:
+  documentation: Transaction hit counts.
+  type: counter
+  values:
+  - labels: {protocol: http, state: fresh}
+    value: proxy.process.http.transaction_counts.hit_fresh
+  - labels: {protocol: http, state: revalidated}
+    value: proxy.process.http.transaction_counts.hit_revalidated
+  - labels: {protocol: http, state: cold}
+    value: 0.0
+  - labels: {protocol: http, state: not_cacheable}
+    value: 0.0
+  - labels: {protocol: http, state: changed}
+    value: 0.0
+trafficserver_transaction_misses_total:
+  documentation: Transaction miss counts.
+  type: counter
+  values:
+  - labels: {protocol: http, state: cold}
+    value: proxy.process.http.transaction_counts.miss_cold
+  - labels: {protocol: http, state: not_cacheable}
+    value: proxy.process.http.transaction_counts.miss_not_cacheable
+  - labels: {protocol: http, state: changed}
+    value: proxy.process.http.transaction_counts.miss_changed
+  - labels: {protocol: http, state: fresh}
+    value: 0.0
+  - labels: {protocol: http, state: revalidated}
+    value: 0.0
+trafficserver_transaction_others_total:
+  documentation: Transaction other/unclassified counts.
+  type: counter
+  values:
+  - labels: {protocol: http, state: unclassified}
+    value: proxy.process.http.transaction_counts.other.unclassified
+trafficserver_transactions_time_ms_total:
+  documentation: Total transaction time (ms).
+  type: counter
+  values:
+  - labels: {}
+    value: proxy.process.http.total_transactions_time
+trafficserver_transactions_total:
+  documentation: Total transactions.
+  type: counter
+  values:
+  - labels: {protocol: http, source: origin_server}
+    value: proxy.node.http.origin_server_total_transactions_count
+  - labels: {protocol: http, source: user_agent}
+    value: proxy.node.http.user_agents_total_transactions_count


### PR DESCRIPTION
Currently a commit is needed to add a new metric. A lot of them can be set using a config file instead of programmatically.

This avoids the requirement of releasing a new trafficserver_exporter version every time a new metric needs to be added